### PR TITLE
fix(core): Fix create database to Metabase

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -288,6 +288,14 @@ class PluginMetabaseAPIClient extends CommonGLPI {
    }
 
    function setFieldCustomMapping($field_id, $label = "") {
+
+      $data = $this->httpQuery("/api/field/$field_id", [
+         'json' => [
+            'special_type'       => 'type/Category',
+            'has_field_values'   => 'list',
+         ]
+      ], 'PUT');
+
       $data = $this->httpQuery("/api/field/$field_id/dimension", [
          'json' => [
             'human_readable_field_id' => null,


### PR DESCRIPTION
With the latest version of Metabase (0.30.4), 
before set field to internal type, 
we need to set special type to 'type/Category' and has_field_values yo 'list'.
otherwise we get a REST error on set custom mapping for field like status / impact etc ...


