### PR TITLE
fix(core): Fix duplicate card creation

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -517,7 +517,7 @@ class PluginMetabaseAPIClient extends CommonGLPI {
       unset($params['database_id']);
       unset($params['sql']);
 
-      if ($card_id = $this->retrieveCard($card_name)) {
+      if ($card_id = $this->retrieveCard($card_name, $params['collection_id'])) {
          $params['original_card_id'] = $card_id;
          // update existing
          $data = $this->httpQuery("card/$card_id", [
@@ -543,8 +543,8 @@ class PluginMetabaseAPIClient extends CommonGLPI {
       return $this->httpQuery("card/$card_id");
    }
 
-   function retrieveCard($card_name) {
-      if (($cards = $this->getCards()) !== false) {
+   function retrieveCard($card_name, $collection_id) {
+      if (($cards = $this->getCards($collection_id)) !== false) {
          $cards = array_column($cards, 'id', 'name');
 
          if (isset($cards[$card_name])) {


### PR DESCRIPTION

Fix duplicate creation of cards when we attempt to regenerate dashboards and questions.

Just passing collection ID to known if exist or not