### PR TITLE
Add GLPI 9.5 compatibility

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@ define('PLUGIN_METABASE_VERSION', '1.0.0');
 // Minimal GLPI version, inclusive
 define("PLUGIN_METABASE_MIN_GLPI", "9.2");
 // Maximum GLPI version, exclusive
-define("PLUGIN_METABASE_MAX_GLPI", "9.5");
+define("PLUGIN_METABASE_MAX_GLPI", "9.6");
 
 if (!defined("PLUGINMETABASE_DIR")) {
    define("PLUGINMETABASE_DIR", GLPI_ROOT . "/plugins/metabase");


### PR DESCRIPTION
I did not find any usage of deprecated or removed GLPI core methods. Unless I miss something, no change is required (except this one) to be able to use plugin on GLPI 9.5.