### PR TITLE
Fix self service view

### DIFF
--- a/front/selfservice.php
+++ b/front/selfservice.php
@@ -5,5 +5,5 @@ Session::checkLoginUser();
 
 Html::helpHeader(__('Metbase'), $_SERVER["PHP_SELF"]);
 $central = new Central;
-PluginMetabaseDashboard::showForCentral($central);
+PluginMetabaseDashboard::showForCentral($central, 0, true);
 Html::helpFooter();

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -60,7 +60,7 @@ class PluginMetabaseDashboard extends CommonDBTM {
     *
     * @return void
     */
-   static function showForCentral(Central $item, $withtemplate = 0) {
+   static function showForCentral(Central $item, $withtemplate = 0, $is_helpdesk = false) {
 
       $apiclient = new PluginMetabaseAPIClient();
 
@@ -95,7 +95,7 @@ class PluginMetabaseDashboard extends CommonDBTM {
          'current_dashboard',
          array_combine(array_column($dashboards, 'id'), array_column($dashboards, 'name')),
          [
-            'on_change' => 'reloadTab("uuid=" + $(this).val());',
+            'on_change' => ($is_helpdesk) ? 'location.href = location.origin+location.pathname+"?uuid="+$(this).val()' : 'reloadTab("uuid=" + $(this).val());',
             'value'     => $currentUuid
          ]
       );


### PR DESCRIPTION

With self-service profile metabase dashabords are not displayed into glpi tab (generated by ```ajax:createTab```)

A JS error occurs when we trying to change dashboard with dropdown

```
13:45:31.823 Uncaught ReferenceError: reloadTab is not defined
    onchange selfservice.php:1
    jQuery 5
    select select2.full.js:3225
    bind select2.full.js:3296
    invoke select2.full.js:655
    trigger select2.full.js:645
    trigger select2.full.js:5827
    _registerResultsEvents select2.full.js:5637
    invoke select2.full.js:655
    trigger select2.full.js:649
    bind select2.full.js:1304
    jQuery 2
selfservice.php:1:1

```

```reloadTab``` is generated when tab is generated by GLPI but here, dashboards are displayed without tab

This PR fix this.