### PR TITLE
fix(code): remove useless code

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -170,8 +170,6 @@ class PluginMetabaseConfig extends Config {
             } else {
                Html::printCleanArray($error);
             }
-
-            echo "<p><strong>".GLPINetwork::getErrorMessage()."</strong></p>";
          }
 
          echo "<div id='actions'>";


### PR DESCRIPTION
to prevent error

```shell
[2021-10-20 15:35:14] glpiphplog.CRITICAL:   *** Uncaught Exception ArgumentCountError: Too few arguments to function CommonGLPI::getErrorMessage(), 0 passed in /htdocs/marketplace/metabase/inc/config.class.php on line 174 and at least 1 expected in /htdocs/inc/commonglpi.class.php at line 1473
  Backtrace :
  marketplace/metabase/inc/config.class.php:174      CommonGLPI::getErrorMessage()
  marketplace/metabase/inc/config.class.php:35       PluginMetabaseConfig::showForConfig()
  inc/commonglpi.class.php:637                       PluginMetabaseConfig::displayTabContentForItem()
  ajax/common.tabs.php:106                           CommonGLPI::displayStandardTab()
```