### PR TITLE
Fix error on dashboard display

### DIFF
--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -142,7 +142,7 @@ class PluginMetabaseDashboard extends CommonDBTM {
           ->getToken($signer_config->signer(), $signer_config->signingKey());
 
       $url = rtrim($config['metabase_url'], '/');
-      echo "<iframe src='$url/embed/dashboard/{$token}#bordered=false'
+      echo "<iframe src='$url/embed/dashboard/{$token->toString()}#bordered=false'
                     id='metabase_iframe'
                     allowtransparency></iframe>";
    }


### PR DESCRIPTION
Fix the following exception :

>[2022-11-30 17:52:18] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Object of class Lcobucci\JWT\Token\Plain could not be converted to string in /var/www/html/glpi/plugins/metabase/inc/dashboard.class.php at line 145
  Backtrace :
  plugins/metabase/inc/dashboard.class.php:74        PluginMetabaseDashboard::showForCentral()
  src/CommonGLPI.php:689                             PluginMetabaseDashboard::displayTabContentForItem()
  src/CommonGLPI.php:653                             CommonGLPI::displayStandardTab()
  ajax/common.tabs.php:113                           CommonGLPI::displayStandardTab()
