### PR TITLE
fix(api): semantic_type for metabase field

### DIFF
--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -362,9 +362,16 @@ class PluginMetabaseAPIClient extends CommonGLPI
 
     public function setFieldCustomMapping($field_id, $label = '')
     {
+
+        $mb_version = $this->getVersion();
+
+        $mb_fieldname = version_compare($mb_version['tag'], 'v0.39.0', '>=')
+            ? 'semantic_type'
+            : 'special_type';
+
         $data = $this->httpQuery("/api/field/$field_id", [
             'json' => [
-                'special_type'     => 'type/Category',
+                $mb_fieldname      => 'type/Category',
                 'has_field_values' => 'list',
             ],
         ], 'PUT');

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -263,7 +263,7 @@ class PluginMetabaseAPIClient extends CommonGLPI
             ? 'semantic_type'
             : 'special_type';
 
-        $data = $this->httpQuery("/api/field/$f_id_src", [
+        $data = $this->httpQuery("field/$f_id_src", [
             'json' => [
                 $mb_fieldname        => 'type/FK',
                 'fk_target_field_id' => $f_id_trgt,
@@ -296,7 +296,7 @@ class PluginMetabaseAPIClient extends CommonGLPI
     {
         $field_id = $_SESSION['metabase']['fields']['glpi_tickets.type'];
         $this->setFieldCustomMapping($field_id, __('Type'));
-        $data = $this->httpQuery("/api/field/$field_id/values", [
+        $data = $this->httpQuery("field/$field_id/values", [
             'json' => [
                 'values' => [
                     [Ticket::INCIDENT_TYPE, __('Incident')],
@@ -318,7 +318,7 @@ class PluginMetabaseAPIClient extends CommonGLPI
         $table    = $item::getTable();
         $field_id = $_SESSION['metabase']['fields']["$table.status"];
         $this->setFieldCustomMapping($field_id, __('Status'));
-        $data = $this->httpQuery("/api/field/$field_id/values", [
+        $data = $this->httpQuery("field/$field_id/values", [
             'json' => [
                 'values' => $statuses_topush,
             ],
@@ -343,7 +343,7 @@ class PluginMetabaseAPIClient extends CommonGLPI
             if ($matrix_field === 'priority') {
                 array_unshift($data_topush, [6, _x($matrix_field, 'Major')]);
             }
-            $data = $this->httpQuery("/api/field/$field_id/values", [
+            $data = $this->httpQuery("field/$field_id/values", [
                 'json' => [
                     'values' => $data_topush,
                 ],
@@ -369,14 +369,14 @@ class PluginMetabaseAPIClient extends CommonGLPI
             ? 'semantic_type'
             : 'special_type';
 
-        $data = $this->httpQuery("/api/field/$field_id", [
+        $data = $this->httpQuery("field/$field_id", [
             'json' => [
                 $mb_fieldname      => 'type/Category',
                 'has_field_values' => 'list',
             ],
         ], 'PUT');
 
-        $data = $this->httpQuery("/api/field/$field_id/dimension", [
+        $data = $this->httpQuery("field/$field_id/dimension", [
             'json' => [
                 'human_readable_field_id' => null,
                 'type'                    => 'internal',

--- a/inc/apiclient.class.php
+++ b/inc/apiclient.class.php
@@ -119,6 +119,22 @@ class PluginMetabaseAPIClient extends CommonGLPI
         return false;
     }
 
+    public function getVersion()
+    {
+        if (!$this->checkSession()) {
+            return false;
+        }
+
+        $data = $this->httpQuery('setting/version');
+
+        if ($data === false) {
+            $this->last_error[] = __('Unable to retrieve Metabase version', 'metabase');
+            return false;
+        }
+
+        return $data;
+    }
+
     public function getCurrentUser($skip_session_check = false)
     {
         if (
@@ -241,9 +257,15 @@ class PluginMetabaseAPIClient extends CommonGLPI
             return false;
         }
 
+        $mb_version = $this->getVersion();
+
+        $mb_fieldname = version_compare($mb_version['tag'], 'v0.39.0', '>=')
+            ? 'semantic_type'
+            : 'special_type';
+
         $data = $this->httpQuery("/api/field/$f_id_src", [
             'json' => [
-                'special_type'       => 'type/FK',
+                $mb_fieldname        => 'type/FK',
                 'fk_target_field_id' => $f_id_trgt,
             ],
         ], 'PUT');


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] My fix is effective or that my feature works.

## Description

Since Metabase 0.39, the key "/api/field/{id}/special_type" has been renamed to ""/api/field/{id}/semantic_type".

So I add a method to check the version, and we name the field accordingly in the API call to push the Foreign Keys.
