### PR TITLE
Manage dashboard access rights per Group and per User

### DIFF
--- a/front/itemright.form.php
+++ b/front/itemright.form.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Metabase plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Metabase.
+ *
+ * Metabase is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Metabase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Metabase. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2018-2023 by Metabase plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/metabase
+ * -------------------------------------------------------------------------
+ *
+ * CUSTOM FORK NOTICE: added to handle per Group / per User dashboard rights.
+ * -------------------------------------------------------------------------
+ */
+
+function plugin_metabase_check_itemright_access($itemtype)
+{
+    if (!in_array($itemtype, PluginMetabaseItemright::SUPPORTED_ITEMTYPES, true)) {
+        Session::addMessageAfterRedirect(
+            __s('Invalid request.', 'metabase'),
+            false,
+            ERROR,
+        );
+        Html::back();
+    }
+
+    if ($itemtype === Group::class) {
+        Session::checkRight('group', UPDATE);
+    } else {
+        Session::checkRight('user', UPDATE);
+    }
+}
+
+if (isset($_REQUEST['update'])) {
+    if (
+        !array_key_exists('itemtype', $_REQUEST)
+        || empty($_REQUEST['itemtype'])
+        || !array_key_exists('items_id', $_REQUEST)
+        || empty($_REQUEST['items_id'])
+        || !array_key_exists('dashboard', $_REQUEST)
+        || !is_array($_REQUEST['dashboard'])
+    ) {
+        Session::addMessageAfterRedirect(
+            __s('Invalid request.', 'metabase'),
+            false,
+            ERROR,
+        );
+        Html::back();
+    }
+
+    plugin_metabase_check_itemright_access($_REQUEST['itemtype']);
+
+    $viewableDashboardsUuids = [];
+    foreach ($_REQUEST['dashboard'] as $dashboardUuid => $rights) {
+        PluginMetabaseItemright::setDashboardRightsForItem(
+            $_REQUEST['itemtype'],
+            $_REQUEST['items_id'],
+            $dashboardUuid,
+            $rights,
+        );
+
+        if (($rights & READ) !== 0) {
+            $viewableDashboardsUuids[] = $dashboardUuid;
+        }
+    }
+
+    if (!empty($viewableDashboardsUuids)) {
+        $apiclient = new PluginMetabaseAPIClient();
+        $apiclient->enableDashboardsEmbeddedDisplay($viewableDashboardsUuids);
+    }
+} elseif (isset($_REQUEST['set_rights_to_all'])) {
+    if (
+        !array_key_exists('itemtype', $_REQUEST)
+        || empty($_REQUEST['itemtype'])
+        || !array_key_exists('items_id', $_REQUEST)
+        || empty($_REQUEST['items_id'])
+    ) {
+        Session::addMessageAfterRedirect(
+            __s('Invalid request.', 'metabase'),
+            false,
+            ERROR,
+        );
+        Html::back();
+    }
+
+    plugin_metabase_check_itemright_access($_REQUEST['itemtype']);
+
+    $apiclient = new PluginMetabaseAPIClient();
+
+    $viewableDashboardsUuids = [];
+    foreach ($apiclient->getDashboards() as $dashboard) {
+        PluginMetabaseItemright::setDashboardRightsForItem(
+            $_REQUEST['itemtype'],
+            $_REQUEST['items_id'],
+            $dashboard['id'],
+            $_REQUEST['set_rights_to_all'],
+        );
+
+        $viewableDashboardsUuids[] = $dashboard['id'];
+    }
+
+    if ((int) $_REQUEST['set_rights_to_all'] !== 0) {
+        $apiclient->enableDashboardsEmbeddedDisplay($viewableDashboardsUuids);
+    }
+}
+
+Html::back();

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -44,6 +44,58 @@ class PluginMetabaseDashboard extends CommonDBTM
     }
 
     /**
+     * Check if the currently logged-in user is able to view at least one
+     * dashboard, combining profile, group and user based rights.
+     *
+     * CUSTOM FORK: rights are additive (OR) across profile / groups / user.
+     *
+     * @return boolean
+     */
+    public static function canCurrentUserViewDashboards(): bool
+    {
+        if (PluginMetabaseProfileright::canProfileViewDashboards($_SESSION['glpiactiveprofile']['id'])) {
+            return true;
+        }
+
+        if (PluginMetabaseItemright::canItemViewDashboards(User::class, Session::getLoginUserID())) {
+            return true;
+        }
+
+        if (PluginMetabaseItemright::canGroupsViewDashboards($_SESSION['glpigroups'] ?? [])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the currently logged-in user is able to view the given
+     * dashboard, combining profile, group and user based rights.
+     *
+     * CUSTOM FORK: rights are additive (OR) across profile / groups / user.
+     *
+     * @param integer $dashboardUuid
+     *
+     * @return boolean
+     */
+    public static function canCurrentUserViewDashboard($dashboardUuid): bool
+    {
+        if (PluginMetabaseProfileright::canProfileViewDashboard($_SESSION['glpiactiveprofile']['id'], $dashboardUuid)) {
+            return true;
+        }
+
+        if (PluginMetabaseItemright::canItemViewDashboard(User::class, Session::getLoginUserID(), $dashboardUuid)) {
+            return true;
+        }
+
+        if (PluginMetabaseItemright::canGroupsViewDashboard($_SESSION['glpigroups'] ?? [], $dashboardUuid)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      * @see CommonGLPI::getTabNameForItem()
      */
@@ -51,7 +103,7 @@ class PluginMetabaseDashboard extends CommonDBTM
     {
         switch ($item->getType()) {
             case 'Central':
-                if (PluginMetabaseProfileright::canProfileViewDashboards($_SESSION['glpiactiveprofile']['id'])) {
+                if (self::canCurrentUserViewDashboards()) {
                     return self::createTabEntry(self::getTypeName(), 0, $item::getType(), PluginMetabaseConfig::getIcon());
                 }
 
@@ -69,7 +121,7 @@ class PluginMetabaseDashboard extends CommonDBTM
     {
         switch (get_class($item)) {
             case Central::class:
-                if (PluginMetabaseProfileright::canProfileViewDashboards($_SESSION['glpiactiveprofile']['id'])) {
+                if (self::canCurrentUserViewDashboards()) {
                     self::showForCentral($item, $withtemplate);
                 }
 
@@ -99,10 +151,7 @@ class PluginMetabaseDashboard extends CommonDBTM
                 $dashboards,
                 function ($dashboard) {
                     $isEmbeddingEnabled = $dashboard['enable_embedding'];
-                    $canView            = PluginMetabaseProfileright::canProfileViewDashboard(
-                        $_SESSION['glpiactiveprofile']['id'],
-                        $dashboard['id'],
-                    );
+                    $canView            = self::canCurrentUserViewDashboard($dashboard['id']);
 
                     return $isEmbeddingEnabled && $canView;
                 },

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -78,7 +78,7 @@ class PluginMetabaseDashboard extends CommonDBTM
      *
      * @return boolean
      */
-    public static function canCurrentUserViewDashboard($dashboardUuid): bool
+    public static function canCurrentUserViewDashboard(int $dashboardUuid): bool
     {
         if (PluginMetabaseProfileright::canProfileViewDashboard($_SESSION['glpiactiveprofile']['id'], $dashboardUuid)) {
             return true;

--- a/inc/dashboard.class.php
+++ b/inc/dashboard.class.php
@@ -72,7 +72,7 @@ class PluginMetabaseDashboard extends CommonDBTM
      * Check if the currently logged-in user is able to view the given
      * dashboard, combining profile, group and user based rights.
      *
-     * CUSTOM FORK: rights are additive (OR) across profile / groups / user.
+     * rights are additive (OR) across profile / groups / user.
      *
      * @param integer $dashboardUuid
      *

--- a/inc/itemright.class.php
+++ b/inc/itemright.class.php
@@ -1,0 +1,405 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Metabase plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Metabase.
+ *
+ * Metabase is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Metabase is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Metabase. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2018-2023 by Metabase plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/metabase
+ * -------------------------------------------------------------------------
+ *
+ * CUSTOM FORK NOTICE
+ * -------------------------------------------------------------------------
+ * This class was added in a local fork to allow defining dashboard access
+ * rights per Group and per User, in addition to the native per Profile
+ * rights handled by PluginMetabaseProfileright.
+ * -------------------------------------------------------------------------
+ */
+
+class PluginMetabaseItemright extends CommonDBTM
+{
+    /**
+     * Itemtypes supported by this "generic" right holder.
+     */
+    public const SUPPORTED_ITEMTYPES = [Group::class, User::class];
+
+    /**
+     * {@inheritDoc}
+     * @see CommonGLPI::getTypeName()
+     */
+    public static function getTypeName($nb = 0)
+    {
+        return __s('Metabase', 'metabase');
+    }
+
+    /**
+     * Returns the GLPI right (and value) required to manage metabase
+     * dashboard rights for the given itemtype.
+     *
+     * @param string $itemtype Group::class or User::class
+     *
+     * @return array{0: string, 1: int} [rightname, right value]
+     */
+    private static function getRequiredRight(string $itemtype): array
+    {
+        return match ($itemtype) {
+            Group::class => ['group', UPDATE],
+            User::class  => ['user', UPDATE],
+            default      => ['profile', UPDATE],
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see CommonGLPI::getTabNameForItem()
+     */
+    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        $itemtype = $item::getType();
+
+        if (!in_array($itemtype, self::SUPPORTED_ITEMTYPES, true)) {
+            return '';
+        }
+
+        [$rightname, $rightvalue] = self::getRequiredRight($itemtype);
+        if (Session::haveRight($rightname, $rightvalue)) {
+            return self::createTabEntry(self::getTypeName(), 0, $itemtype, PluginMetabaseConfig::getIcon());
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see CommonGLPI::displayTabContentForItem()
+     */
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
+    {
+        $itemtype = $item::getType();
+
+        if (!in_array($itemtype, self::SUPPORTED_ITEMTYPES, true)) {
+            return true;
+        }
+
+        [$rightname, $rightvalue] = self::getRequiredRight($itemtype);
+        if (Session::haveRight($rightname, $rightvalue)) {
+            $itemright = new self();
+            $itemright->showRightsForm($itemtype, $item->fields['id']);
+        }
+
+        return true;
+    }
+
+    /**
+     * Display item (group/user) rights form.
+     *
+     * @param string  $itemtype Group::class or User::class
+     * @param integer $itemsId  Group or User id
+     * @param array   $options
+     *
+     * @return bool
+     */
+    public function showRightsForm($itemtype, $itemsId, $options = [])
+    {
+        if (!in_array($itemtype, self::SUPPORTED_ITEMTYPES, true)) {
+            return false;
+        }
+
+        [$rightname, $rightvalue] = self::getRequiredRight($itemtype);
+        if (!Session::haveRight($rightname, $rightvalue)) {
+            return false;
+        }
+
+        $apiclient  = new PluginMetabaseAPIClient();
+        $dashboards = $apiclient->getDashboards();
+
+        if (!$dashboards) {
+            echo '<div class="alert alert-warning">' . __s('No dashboards found in Metabase.', 'metabase') . '</div>';
+            return false;
+        }
+
+        echo '<form method="post" action="' . self::getFormURL() . '">';
+        echo '<div class="spaced" id="tabsbody">';
+        echo '<table class="tab_cadre_fixe" id="mainformtable">';
+
+        echo '<tr class="headerRow"><th colspan="2">' . self::getTypeName() . '</th></tr>';
+
+        Plugin::doHook('pre_item_form', ['item' => $this, 'options' => &$options]);
+
+        echo '<tr><th colspan="2">' . __s('Rights management', 'metabase') . '</th></tr>';
+
+        echo '<input type="hidden" name="itemtype" value="' . $itemtype . '" />';
+        echo '<input type="hidden" name="items_id" value="' . $itemsId . '" />';
+
+        echo '<tr class="tab_bg_4">';
+        echo '<td colspan="2" class="center">';
+        echo '<button type="submit" class="btn btn-outline-secondary" name="set_rights_to_all" value="1">'
+        . "<i class='ti ti-check'></i>"
+        . '<span>' . __s('Allow access to all', 'metabase') . '</span>'
+        . '</button>';
+        echo ' &nbsp; ';
+        echo '<button type="submit" class="btn btn-outline-secondary" name="set_rights_to_all" value="0">'
+        . "<i class='ti ti-forbid'></i>"
+        . '<span>' . __s('Disallow access to all', 'metabase') . '</span>'
+        . '</button>';
+        echo '</td>';
+        echo '</tr>';
+
+        foreach ($dashboards as $dashboard) {
+            echo '<tr class="tab_bg_1">';
+            echo '<td>' . $dashboard['name'] . '</td>';
+            echo '<td>';
+            Profile::dropdownRight(
+                sprintf('dashboard[%d]', $dashboard['id']),
+                [
+                    'value'   => self::getItemRightForDashboard($itemtype, $itemsId, $dashboard['id']),
+                    'nonone'  => 0,
+                    'noread'  => 0,
+                    'nowrite' => 1,
+                ],
+            );
+            echo '</td>';
+            echo '</tr>';
+        }
+
+        echo '<tr class="tab_bg_4">';
+        echo '<td colspan="2" class="center">';
+        echo Html::submit(_sx('button', 'Save'), [
+            'name'  => 'update',
+            'icon'  => 'ti ti-device-floppy',
+            'class' => 'btn btn-primary',
+        ]);
+        echo '</td>';
+        echo '</tr>';
+
+        echo '</table>';
+        echo '</div>';
+
+        Html::closeForm();
+
+        return true;
+    }
+
+    /**
+     * Check if any group from the given list is able to view at least one dashboard.
+     *
+     * @param int[] $groupIds
+     *
+     * @return boolean
+     */
+    public static function canGroupsViewDashboards(array $groupIds): bool
+    {
+        foreach ($groupIds as $groupId) {
+            if (self::canItemViewDashboards(Group::class, $groupId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if any group from the given list is able to view the given dashboard.
+     *
+     * @param int[]   $groupIds
+     * @param integer $dashboardUuid
+     *
+     * @return boolean
+     */
+    public static function canGroupsViewDashboard(array $groupIds, $dashboardUuid): bool
+    {
+        foreach ($groupIds as $groupId) {
+            if (self::canItemViewDashboard(Group::class, $groupId, $dashboardUuid)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if item (group/user) is able to view at least one dashboard.
+     *
+     * @param string  $itemtype
+     * @param integer $itemsId
+     *
+     * @return boolean
+     */
+    public static function canItemViewDashboards($itemtype, $itemsId): bool
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        if (empty($itemsId)) {
+            return false;
+        }
+
+        $iterator = $DB->request(
+            [
+                'FROM'  => self::getTable(),
+                'WHERE' => [
+                    'itemtype' => $itemtype,
+                    'items_id' => $itemsId,
+                ],
+            ],
+        );
+
+        foreach ($iterator as $right) {
+            if (($right['rights'] & READ) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if item (group/user) is able to view given dashboard.
+     *
+     * @param string  $itemtype
+     * @param integer $itemsId
+     * @param integer $dashboardUuid
+     *
+     * @return boolean
+     */
+    public static function canItemViewDashboard($itemtype, $itemsId, $dashboardUuid): bool
+    {
+        return (self::getItemRightForDashboard($itemtype, $itemsId, $dashboardUuid) & READ) !== 0;
+    }
+
+    /**
+     * Returns item (group/user) rights for given dashboard.
+     *
+     * @param string  $itemtype
+     * @param integer $itemsId
+     * @param integer $dashboardUuid
+     *
+     * @return integer
+     */
+    private static function getItemRightForDashboard($itemtype, $itemsId, $dashboardUuid)
+    {
+        if (empty($itemsId)) {
+            return 0;
+        }
+
+        $rightCriteria = [
+            'itemtype'       => $itemtype,
+            'items_id'       => $itemsId,
+            'dashboard_uuid' => $dashboardUuid,
+        ];
+
+        $itemright = new self();
+        if ($itemright->getFromDBByCrit($rightCriteria)) {
+            return $itemright->fields['rights'];
+        }
+
+        return 0;
+    }
+
+    /**
+     * Defines item (group/user) rights for dashboard.
+     *
+     * @param string  $itemtype
+     * @param integer $itemsId
+     * @param integer $dashboardUuid
+     * @param integer $rights
+     *
+     * @return void
+     */
+    public static function setDashboardRightsForItem($itemtype, $itemsId, $dashboardUuid, $rights)
+    {
+        $itemright = new self();
+
+        $rightsExists = $itemright->getFromDBByCrit(
+            [
+                'itemtype'       => $itemtype,
+                'items_id'       => $itemsId,
+                'dashboard_uuid' => $dashboardUuid,
+            ],
+        );
+
+        if ($rightsExists) {
+            $itemright->update(
+                [
+                    'id'     => $itemright->fields['id'],
+                    'rights' => $rights,
+                ],
+            );
+        } else {
+            $itemright->add(
+                [
+                    'itemtype'       => $itemtype,
+                    'items_id'       => $itemsId,
+                    'dashboard_uuid' => $dashboardUuid,
+                    'rights'         => $rights,
+                ],
+            );
+        }
+    }
+
+    /**
+     * Install itemrights database.
+     *
+     * @param Migration $migration
+     *
+     * @return void
+     */
+    public static function install(Migration $migration)
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $default_charset   = DBConnection::getDefaultCharset();
+        $default_collation = DBConnection::getDefaultCollation();
+        $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
+
+        $table = self::getTable();
+
+        if (!$DB->tableExists($table)) {
+            $migration->displayMessage("Installing $table");
+
+            $query = "CREATE TABLE IF NOT EXISTS `$table` (
+                     `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+                     `itemtype` varchar(100) NOT NULL,
+                     `items_id` int {$default_key_sign} NOT NULL,
+                     `dashboard_uuid` int NOT NULL,
+                     `rights` int NOT NULL,
+                     PRIMARY KEY (`id`),
+                     UNIQUE `itemtype_items_id_dashboard_uuid` (`itemtype`, `items_id`, `dashboard_uuid`)
+                  ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
+            $DB->doQuery($query);
+        }
+    }
+
+    /**
+     * Uninstall itemrights database.
+     *
+     * @return void
+     */
+    public static function uninstall()
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $DB->doQuery('DROP TABLE IF EXISTS `' . self::getTable() . '`');
+    }
+}

--- a/inc/itemright.class.php
+++ b/inc/itemright.class.php
@@ -227,8 +227,24 @@ class PluginMetabaseItemright extends CommonDBTM
      */
     public static function canGroupsViewDashboard(array $groupIds, $dashboardUuid): bool
     {
-        foreach ($groupIds as $groupId) {
-            if (self::canItemViewDashboard(Group::class, $groupId, $dashboardUuid)) {
+        if (empty($groupIds)) {
+            return false;
+        }
+
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'  => self::getTable(),
+            'WHERE' => [
+                'itemtype'       => Group::class,
+                'items_id'       => $groupIds,
+                'dashboard_uuid' => $dashboardUuid,
+            ],
+        ]);
+
+        foreach ($iterator as $right) {
+            if (($right['rights'] & READ) !== 0) {
                 return true;
             }
         }

--- a/inc/itemright.class.php
+++ b/inc/itemright.class.php
@@ -222,9 +222,32 @@ class PluginMetabaseItemright extends CommonDBTM
      *
      * @param int[]   $groupIds
      * @param integer $dashboardUuid
-     *
-     * @return boolean
-     */
+    public static function canGroupsViewDashboards(array $groupIds): bool
+    {
+        if (empty($groupIds)) {
+            return false;
+        }
+
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $iterator = $DB->request([
+            'FROM'  => self::getTable(),
+            'WHERE' => [
+                'itemtype' => Group::class,
+                'items_id' => $groupIds,
+            ],
+        ]);
+
+        foreach ($iterator as $right) {
+            if (($right['rights'] & READ) !== 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static function canGroupsViewDashboard(array $groupIds, $dashboardUuid): bool
     {
         if (empty($groupIds)) {

--- a/setup.php
+++ b/setup.php
@@ -78,7 +78,7 @@ function plugin_init_metabase()
     //display helpdesk menu if self-service and if is able to view at least one dashboard.
     if (
         $_SESSION['glpiactiveprofile']['interface'] == 'helpdesk'
-        && PluginMetabaseProfileright::canProfileViewDashboards($_SESSION['glpiactiveprofile']['id'])
+        && PluginMetabaseDashboard::canCurrentUserViewDashboards()
     ) {
         $PLUGIN_HOOKS['helpdesk_menu_entry']['metabase']      = '/front/selfservice.php';
         $PLUGIN_HOOKS['helpdesk_menu_entry_icon']['metabase'] = 'ti ti-chart-bar';
@@ -87,6 +87,9 @@ function plugin_init_metabase()
 
     // profile rights management
     Plugin::registerClass('PluginMetabaseProfileright', ['addtabon' => 'Profile']);
+
+    // CUSTOM FORK: group / user rights management
+    Plugin::registerClass('PluginMetabaseItemright', ['addtabon' => ['Group', 'User']]);
 
     // css & js
     $PLUGIN_HOOKS['add_css']['metabase']        = 'metabase.css';


### PR DESCRIPTION
Update to better manage access to the dashboards.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Currently, dashboard access can only be granted per Profile. This PR adds the ability to also grant (or deny) access per Group and per User, using the same rights mechanism (`Profile::dropdownRight`) already used for profiles.

- Adds a new `PluginMetabaseItemright` class, mirroring `PluginMetabaseProfileright`, storing rights keyed by `itemtype` (`Group` or `User`) + `items_id` + `dashboard_uuid`.
- Adds a new tab ("Metabase") on the Group and User forms, gated by the existing `group`/`user` UPDATE rights, to manage dashboard access for that group/user.
- Access rights are now additive: a dashboard is shown on Central if the user's profile, any of their groups, or the user themselves has been granted READ access.
- No changes to the existing profile-based rights: they keep working exactly as before, this is purely additive.

I did not add automated tests since the plugin doesn't currently have a test suite in place.

## Screenshots:

<img width="1913" height="909" alt="Group" src="https://github.com/user-attachments/assets/d8dbcf08-fd57-4fa7-9e0e-9477c2e5349d" />
<img width="1918" height="879" alt="User" src="https://github.com/user-attachments/assets/013daeea-53a0-4c91-a605-9690c6e20104" />
